### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -9,6 +9,14 @@
       expect(data).toEqual({ name: 'afei' });
     });
 
+    test('set can prevent prototype pollution', function () {
+      var data = {};
+      var operator = new NxObjectOperator(data);
+      operator.set('__proto__.polluted', 'Yes, its polluted.');
+      expect(data.polluted).toEqual(undefined);
+      expect({}.polluted).toEqual(undefined);
+    });
+
     test('get should get the right value', function () {
       var data = {};
       var operator = new NxObjectOperator(data);

--- a/src/index.js
+++ b/src/index.js
@@ -2,19 +2,30 @@
   var global = global || this || window || Function('return this')();
   var nx = global.nx || require('@jswork/next');
 
+  var isPrototypePolluted = function(key) {
+    return ['__proto__', 'prototype', 'constructor'].includes(key);
+  }
+
+  var set = function(data, key, value) {
+    if (String(key).split(".").some(function(k) {
+      return isPrototypePolluted(k);
+    })) return false;
+    nx.set(data, key, value);
+  }
+
   var NxObjectOperator = nx.declare('nx.ObjectOperator', {
     methods: {
       init: function (inData) {
         this.data = inData;
       },
       set: function (inPath, inValue) {
-        nx.set(this.data, inPath, inValue);
+        set(this.data, inPath, inValue);
       },
       sets: function (inObject) {
         nx.forIn(
           inObject,
           function (key, value) {
-            nx.set(this.data, key, value);
+            set(this.data, key, value);
           },
           this
         );


### PR DESCRIPTION
https://huntr.dev/users/d3v53c has fixed the Prototype Pollution vulnerability 🔨. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/next-object-operator/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/@feizheng/next-object-operator/1/README.md

### User Comments:

### 📊 Metadata *

@feizheng/next-object-operator is vulnerable to Prototype Pollution. This package fails to restrict access to prototypes of objects, allowing for modification of prototype behavior using a proto payload, which may result in Sensitive Information Disclosure/Denial of Service(DoS)/Remote Code Execution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40feizheng%2Fnext-object-operator

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:

```
// poc.js
var nextObjectOperator = require("@feizheng/next-object-operator")

const data = {};
const operator = new nextObjectOperator(data);

console.log("Before : " + {}.polluted);
operator.set('__proto__.polluted', 'Yes! Its Polluted')
console.log("After : " + {}.polluted);
```

Execute the following commands in another terminal:

```
npm i @feizheng/next-object-operator # Install affected module
node poc.js #  Run the PoC
```

Check the Output:

```
Before : undefined
After : Yes! Its Polluted
```

### 🔥 Proof of Fix (PoF) *

Before:

![image](https://user-images.githubusercontent.com/64132745/104725911-c2b03b00-5758-11eb-9e75-68ce7df6707c.png)

After:

![image](https://user-images.githubusercontent.com/64132745/104725987-e4a9bd80-5758-11eb-8cc4-ee0d5bb0a036.png)


### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/104726398-88936900-5759-11eb-9e91-743ed5c07a13.png)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://www.huntr.dev/bounties/1-npm-%40feizheng%2Fnext-object-operator/
